### PR TITLE
Feat/multi language add command

### DIFF
--- a/src/api/KeysAPI.ts
+++ b/src/api/KeysAPI.ts
@@ -2,7 +2,27 @@ import { exit } from "process";
 import { Logger } from "../Logger";
 import { Validators } from "../Validators";
 import { API } from "./API";
+import { LanguagesAPI, IGetLanguagesResponse } from "./LanguagesAPI";
 import { TranslationsAPI } from "./TranslationsAPI";
+
+function buildLangCodeToIdMap(response: IGetLanguagesResponse): Map<string, string> {
+    const map = new Map<string, string>();
+    const included = response.included || [];
+
+    for (const lang of response.data || []) {
+        const langCodeRef = lang.relationships?.language_code?.data;
+        if (langCodeRef) {
+            const langCodeObj = included.find(
+                (inc) => inc.id === langCodeRef.id && inc.type === "language_code"
+            );
+            if (langCodeObj) {
+                map.set(langCodeObj.attributes.code, lang.attributes.id);
+            }
+        }
+    }
+
+    return map;
+}
 
 const KeysAPI = {
     getKeys: async (projectId: string) => {
@@ -14,16 +34,24 @@ const KeysAPI = {
         name: string;
         defaultLanguageTranslation?: string;
         description: string;
+        langTranslations?: { [langCode: string]: string };
     }) => {
         const newKey: any = await API.postRequest(`projects/${options.projectId}/keys`, {
             name: options.name,
             description: options.description
         });
 
-        if (!newKey.error && newKey.data && options.defaultLanguageTranslation) {
+        if (newKey.error) {
+            return newKey;
+        }
+
+        const keyId = newKey.data.attributes.id;
+
+        // Existing behavior: default language translation (no explicit language ID)
+        if (options.defaultLanguageTranslation) {
             const newTranslationResponse: any = await TranslationsAPI.createTranslation({
                 content: options.defaultLanguageTranslation,
-                keyId: newKey.data.attributes.id,
+                keyId: keyId,
                 projectId: options.projectId
             });
 
@@ -31,6 +59,33 @@ const KeysAPI = {
                 Logger.error(
                     "You need to define a default language if you want to add translations for your default language directly when creating a new key."
                 );
+            }
+        }
+
+        // New behavior: explicit language-code translations
+        if (options.langTranslations && Object.keys(options.langTranslations).length > 0) {
+            const languagesResponse: IGetLanguagesResponse = await LanguagesAPI.getLanguages(options.projectId);
+            const langCodeToId = buildLangCodeToIdMap(languagesResponse);
+
+            for (const [langCode, content] of Object.entries(options.langTranslations)) {
+                const languageId = langCodeToId.get(langCode);
+                if (!languageId) {
+                    Logger.warn(`Language code "${langCode}" not found in project. Skipping.`);
+                    continue;
+                }
+
+                const translationResponse: any = await TranslationsAPI.createTranslation({
+                    content,
+                    keyId,
+                    languageId,
+                    projectId: options.projectId
+                });
+
+                if (translationResponse.error) {
+                    Logger.warn(`Failed to create translation for language "${langCode}".`);
+                } else {
+                    Logger.success(`Translation for "${langCode}" added.`);
+                }
             }
         }
 

--- a/src/api/KeysAPI.ts
+++ b/src/api/KeysAPI.ts
@@ -16,7 +16,7 @@ function buildLangCodeToIdMap(response: IGetLanguagesResponse): Map<string, stri
                 (inc) => inc.id === langCodeRef.id && inc.type === "language_code"
             );
             if (langCodeObj) {
-                map.set(langCodeObj.attributes.code, lang.attributes.id);
+                map.set(langCodeObj.attributes.code, lang.id);
             }
         }
     }
@@ -64,28 +64,32 @@ const KeysAPI = {
 
         // New behavior: explicit language-code translations
         if (options.langTranslations && Object.keys(options.langTranslations).length > 0) {
-            const languagesResponse: IGetLanguagesResponse = await LanguagesAPI.getLanguages(options.projectId);
-            const langCodeToId = buildLangCodeToIdMap(languagesResponse);
+            try {
+                const languagesResponse: IGetLanguagesResponse = await LanguagesAPI.getLanguages(options.projectId);
+                const langCodeToId = buildLangCodeToIdMap(languagesResponse);
 
-            for (const [langCode, content] of Object.entries(options.langTranslations)) {
-                const languageId = langCodeToId.get(langCode);
-                if (!languageId) {
-                    Logger.warn(`Language code "${langCode}" not found in project. Skipping.`);
-                    continue;
+                for (const [langCode, content] of Object.entries(options.langTranslations)) {
+                    const languageId = langCodeToId.get(langCode);
+                    if (!languageId) {
+                        Logger.warn(`Language code "${langCode}" not found in project. Skipping.`);
+                        continue;
+                    }
+
+                    const translationResponse: any = await TranslationsAPI.createTranslation({
+                        content,
+                        keyId,
+                        languageId,
+                        projectId: options.projectId
+                    });
+
+                    if (translationResponse.error) {
+                        Logger.warn(`Failed to create translation for language "${langCode}".`);
+                    } else {
+                        Logger.success(`Translation for "${langCode}" added.`);
+                    }
                 }
-
-                const translationResponse: any = await TranslationsAPI.createTranslation({
-                    content,
-                    keyId,
-                    languageId,
-                    projectId: options.projectId
-                });
-
-                if (translationResponse.error) {
-                    Logger.warn(`Failed to create translation for language "${langCode}".`);
-                } else {
-                    Logger.success(`Translation for "${langCode}" added.`);
-                }
+            } catch (e) {
+                Logger.warn("Failed to fetch project languages. Skipping language-specific translations.");
             }
         }
 

--- a/src/api/KeysAPI.ts
+++ b/src/api/KeysAPI.ts
@@ -16,6 +16,7 @@ function buildLangCodeToIdMap(response: IGetLanguagesResponse): Map<string, stri
                 (inc) => inc.id === langCodeRef.id && inc.type === "language_code"
             );
             if (langCodeObj) {
+                // Use lang.id (top-level JSON:API resource identifier) as the canonical UUID
                 map.set(langCodeObj.attributes.code, lang.id);
             }
         }
@@ -89,7 +90,7 @@ const KeysAPI = {
                     }
                 }
             } catch (e) {
-                Logger.warn("Failed to fetch project languages. Skipping language-specific translations.");
+                Logger.warn("Failed to create language-specific translations.");
             }
         }
 

--- a/src/api/LanguagesAPI.ts
+++ b/src/api/LanguagesAPI.ts
@@ -1,0 +1,40 @@
+import { API } from "./API";
+
+export interface ILanguageCode {
+    id: string;
+    type: "language_code";
+    attributes: {
+        id: string;
+        name: string;
+        code: string;
+    };
+}
+
+export interface ILanguage {
+    id: string;
+    type: "language";
+    attributes: {
+        id: string;
+        name: string;
+        is_default: boolean;
+    };
+    relationships: {
+        language_code: {
+            data: { id: string; type: "language_code" } | null;
+        };
+    };
+}
+
+export interface IGetLanguagesResponse {
+    data: ILanguage[];
+    included: ILanguageCode[];
+    meta: { total: number };
+}
+
+const LanguagesAPI = {
+    getLanguages: async (projectId: string): Promise<IGetLanguagesResponse> => {
+        return API.getRequest(`projects/${projectId}/languages`, { show_all: true });
+    }
+};
+
+export { LanguagesAPI };

--- a/src/api/LanguagesAPI.ts
+++ b/src/api/LanguagesAPI.ts
@@ -27,7 +27,7 @@ export interface ILanguage {
 
 export interface IGetLanguagesResponse {
     data: ILanguage[];
-    included: ILanguageCode[];
+    included?: ILanguageCode[];
     meta: { total: number };
 }
 

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -56,7 +56,14 @@ export default class Add extends Command {
         const langTranslations: { [langCode: string]: string } = {};
         let defaultContent: string | undefined;
 
-        for (const arg of argv as string[]) {
+        // If oclif included the declared "name" positional in argv, skip it.
+        // Also skip flag-like tokens (starting with "-") that may appear in strict: false mode.
+        const extraArgs = (argv as string[])[0] === args.name
+            ? (argv as string[]).slice(1)
+            : (argv as string[]);
+
+        for (const arg of extraArgs) {
+            if (arg.startsWith("-")) continue; // skip flag tokens
             const eqIndex = arg.indexOf("=");
             if (eqIndex > 0) {
                 const langCode = arg.substring(0, eqIndex);
@@ -65,6 +72,13 @@ export default class Add extends Command {
             } else {
                 defaultContent = arg;
             }
+        }
+
+        if (defaultContent && Object.keys(langTranslations).length > 0) {
+            Logger.warn(
+                "Both a default translation and language-specific translations were provided. " +
+                "The default translation will target the project's default language."
+            );
         }
 
         let response: any;

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -56,14 +56,12 @@ export default class Add extends Command {
         const langTranslations: { [langCode: string]: string } = {};
         let defaultContent: string | undefined;
 
-        // If oclif included the declared "name" positional in argv, skip it.
-        // Also skip flag-like tokens (starting with "-") that may appear in strict: false mode.
-        const extraArgs = (argv as string[])[0] === args.name
-            ? (argv as string[]).slice(1)
-            : (argv as string[]);
+        // Filter out the declared key name arg and any flag-like tokens from argv
+        const extraArgs = (argv as string[]).filter(
+            (tok) => tok !== args.name && !tok.startsWith("-")
+        );
 
         for (const arg of extraArgs) {
-            if (arg.startsWith("-")) continue; // skip flag tokens
             const eqIndex = arg.indexOf("=");
             if (eqIndex > 0) {
                 const langCode = arg.substring(0, eqIndex);

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -15,6 +15,8 @@ import { help_flag } from "../flags/help_flag";
 export default class Add extends Command {
     static description = "add a new key with an optional default language translation content";
 
+    static strict = false;
+
     static flags = {
         help: help_flag,
         "project-path": Flags.string(),
@@ -23,15 +25,17 @@ export default class Add extends Command {
         "auth-secret": auth_secret_flag
     };
 
-    static args = [{ name: "name", required: true }, { name: "content" }];
+    static args = [{ name: "name", required: true }];
 
     static examples = [
         '$ texterify add "app.title" "MyApp" --description "The name of the app."',
-        '$ texterify add "app.description" "My app description"'
+        '$ texterify add "app.description" "My app description"',
+        '$ texterify add "app.title" en="MyApp" de="MeineApp"',
+        '$ texterify add "app.title" en="MyApp" de="MeineApp" --description "The app name"'
     ];
 
     async run() {
-        const { args, flags } = await this.parse(Add);
+        const { args, flags, argv } = await this.parse(Add);
         Settings.setAuthCredentialsPassedViaCLI({
             email: flags["auth-email"],
             secret: flags["auth-secret"]
@@ -48,13 +52,29 @@ export default class Add extends Command {
         const projectId = Settings.getProjectID();
         Validators.ensureProjectId(projectId);
 
+        // Parse remaining positional args: "lang=content" pairs or plain default content
+        const langTranslations: { [langCode: string]: string } = {};
+        let defaultContent: string | undefined;
+
+        for (const arg of argv as string[]) {
+            const eqIndex = arg.indexOf("=");
+            if (eqIndex > 0) {
+                const langCode = arg.substring(0, eqIndex);
+                const content = arg.substring(eqIndex + 1);
+                langTranslations[langCode] = content;
+            } else {
+                defaultContent = arg;
+            }
+        }
+
         let response: any;
         try {
             response = await KeysAPI.createKey({
                 projectId: projectId,
                 name: args.name,
                 description: flags.description || "",
-                defaultLanguageTranslation: args.content
+                defaultLanguageTranslation: defaultContent,
+                langTranslations: Object.keys(langTranslations).length > 0 ? langTranslations : undefined
             });
         } catch (error) {
             Logger.error("Failed to add key.");

--- a/test/commands/add.test.ts
+++ b/test/commands/add.test.ts
@@ -17,4 +17,21 @@ describe("add", () => {
     test.command(["add", `app.title-${uuid.v4()}`, "MyApp", "--description", "The name of the app."]).it(
         "succeeds with key name, translation and description"
     );
+
+    test.command(["add", `app.title-${uuid.v4()}`, "en=MyApp"]).it("succeeds with single lang=content arg");
+
+    test.command(["add", `app.title-${uuid.v4()}`, "en=MyApp", "de=MeineApp"]).it(
+        "succeeds with multiple lang=content args"
+    );
+
+    test.command(["add", `app.title-${uuid.v4()}`, "en=MyApp", "de=MeineApp", "--description", "The app name."]).it(
+        "succeeds with multiple lang=content args and description"
+    );
+
+    test.command(["add", `app.title-${uuid.v4()}`, "unknown_lang=Hello"]).it(
+        "succeeds but warns when lang code is not found in project"
+    );
+
+    // Backward compat: existing plain content arg still works
+    test.command(["add", `app.title-${uuid.v4()}`, "MyApp"]).it("still succeeds with plain content (backward compat)");
 });


### PR DESCRIPTION
# Multi-Language Translation Support for `add` Command


## Problem

The existing `texterify add` command only supports adding a key with an optional translation for the project's **default language**. To add translations for additional languages, users must manually call the API or use the web UI — there is no CLI workflow for it.

## Goal

Extend the `add` command to accept `lang_code=content` pairs as extra positional arguments, so users can upload a key with translations for multiple specific languages in one command.

```sh
texterify add "app.title" en="MyApp" de="MeineApp"
```

## Constraints

- No backend changes required — existing API endpoints are sufficient.
- Backward compatibility: existing `texterify add "key" "content"` (default language) must still work.
- Language identified by language code (e.g., `en`, `de`) not by UUID.

## Architecture

### Data Flow

```
User: texterify add my.key en="Hello" de="Hallo"
  1. Parse: name="my.key", extras=["en=Hello", "de=Hallo"]
  2. GET /projects/:id/languages?show_all=true
     → build map: { "en" → <uuid>, "de" → <uuid> }
  3. POST /projects/:id/keys { name: "my.key", description: "" }
     → get new key ID
  4. POST /projects/:id/translations { language_id: <en-id>, key_id: <key-id>, content: "Hello" }
  5. POST /projects/:id/translations { language_id: <de-id>, key_id: <key-id>, content: "Hallo" }
```

### API Endpoints Used (all existing)

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/projects/:id/languages?show_all=true` | Resolve language codes → IDs |
| POST | `/projects/:id/keys` | Create the key |
| POST | `/projects/:id/translations` | Create each translation |

## Files Changed

### New: `src/api/LanguagesAPI.ts`

Thin wrapper around the languages endpoint. Returns the full JSON:API response including `included` with `language_code` relationships, so the caller can resolve `language_code.code` → `language.id`.

### Modified: `src/api/KeysAPI.ts`

`createKey` gains an optional `translations` parameter:

```ts
translations?: { [langCode: string]: string }
```

After creating the key, it:
1. Fetches all project languages (calls `LanguagesAPI.getLanguages`)
2. Builds a `code → id` map by walking the JSON:API `included` array
3. For each entry in `translations`, finds the matching language ID and calls `TranslationsAPI.createTranslation`

### Modified: `src/commands/add.ts`

- `static strict = false` added — allows extra positional args beyond the defined ones
- `argv` from `this.parse(Add)` is inspected for extra items (non-flag strings)
- Items containing `=` are treated as `lang=content` pairs
- Items without `=` are treated as the plain default-language `content` (backward compat)
- Successes and warnings (unknown language code) are printed per translation

## UX

### Before
```sh
texterify add "app.title" "MyApp"
texterify add "app.title" "MyApp" --description "The app name"
```

### After (backward compatible)
```sh
# Unchanged — still works
texterify add "app.title" "MyApp"

# New: specific language translations
texterify add "app.title" en="MyApp" de="MeineApp"

# New: multiple languages with description
texterify add "app.title" en="MyApp" de="MeineApp" --description "The app name"
```

## Error Handling

| Scenario | Behavior |
|----------|----------|
| Unknown language code | Warn user, skip that translation, continue |
| Key creation fails | Print error, abort (no translations created) |
| Translation creation fails | Warn user, continue with remaining translations |
| Project has no languages | Warn user if any lang= pairs were given |

## Testing

Add test cases in `test/` directory (mocha + nock) covering:
- Existing `add key content` still works
- `add key en=content` creates key + one translation
- `add key en=a de=b` creates key + two translations
- Unknown language code triggers warning but doesn't abort
